### PR TITLE
Moving farady to dependency dependency

### DIFF
--- a/faraday-net_http_persistent.gemspec
+++ b/faraday-net_http_persistent.gemspec
@@ -22,10 +22,10 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob("lib/**/*") + %w[README.md LICENSE.md]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "~> 1.0"
   spec.add_dependency "net-http-persistent", "~> 3.1"
 
   spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "faraday", "~> 1.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov", "~> 0.19.0"


### PR DESCRIPTION
https://github.com/lostisland/faraday/pull/1250#issuecomment-802407668

I ran into the error:

> Your bundle requires gems that depend on each other, creating an infinite loop. Please remove either gem 'faraday' or gem 'faraday-net_http_persistent' and try again.

While replacing NetHttpPersistent with this gem. It was totally down to me adding faraday as a dependency instead of a a development dependency.

This is the fix to solve that so we can replace this in the main gem :)

Once this is in, I can update https://github.com/lostisland/faraday/pull/1250 