### PR TITLE
Declearing net-http-persistent gem requirement in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 # TODO: remove this once v4 is released
-options = (RUBY_VERSION.start_with?('3') ? { github: 'grosser/net-http-persistent', branch: 'grosser/spec' } : {})
+options = (RUBY_VERSION.start_with?("3") ? {github: "grosser/net-http-persistent", branch: "grosser/spec"} : {})
 gem "net-http-persistent", ">= 3.1", **options
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
+
+# TODO: remove this once v4 is released
+options = (RUBY_VERSION.start_with?('3') ? { github: 'grosser/net-http-persistent', branch: 'grosser/spec' } : {})
+gem "net-http-persistent", ">= 3.1", **options
+
 gemspec

--- a/faraday-net_http_persistent.gemspec
+++ b/faraday-net_http_persistent.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob("lib/**/*") + %w[README.md LICENSE.md]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "net-http-persistent", "~> 3.1"
+  spec.add_dependency "net-http-persistent", ">= 3.1"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "faraday", "~> 1.0"


### PR DESCRIPTION
I'm aiming to get this hooked up to the main Farady repo ( https://github.com/lostisland/faraday/pull/1250 ), but it's delayed because the `net-http-persistent` gem hasn't had a release recently.

This points to a forked version of the gem in Gemfile, which should mean this will run on Ruby 3.0.0