### PR TITLE
feat: Adding support for streamed responses

### DIFF
--- a/spec/faraday/adapter/net_http_persistent_spec.rb
+++ b/spec/faraday/adapter/net_http_persistent_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Faraday::Adapter::NetHttpPersistent do
-  features :request_body_on_query_methods, :reason_phrase_parse, :compression, :trace_method
+  features :request_body_on_query_methods, :reason_phrase_parse, :compression, :trace_method, :streaming
 
   it_behaves_like "an adapter"
 


### PR DESCRIPTION
Closes: https://github.com/lostisland/faraday-net_http_persistent/issues/5

This adds support for a streamed response and is based on the
implementation I saw https://github.com/lostisland/faraday-net_http/blob/9534fd19bd4898f28361ea60dbc3867edadc15ad/lib/faraday/adapter/net_http.rb#L106-L120

The tests are all passing (Yay), I also ran the steps to reproduce provided by @wconrad (Thank you so much, this helped a bunch) locally & had the result (I also tried a few other links, though I didn't check any massive files):
<img width="731" alt="image" src="https://user-images.githubusercontent.com/325384/125209926-072d1700-e262-11eb-9c85-c060708e0656.png">