### PR TITLE
Prepare this adapter for Faraday 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,4 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
-
-# TODO: remove this once v4 is released
-options = (RUBY_VERSION.start_with?("3") ? {github: "grosser/net-http-persistent", branch: "grosser/spec"} : {})
-gem "net-http-persistent", ">= 3.1", **options
-
 gemspec

--- a/README.md
+++ b/README.md
@@ -5,27 +5,31 @@
 
 This gem is a [Faraday][faraday] adapter for the [Net::HTTP::Persistent gem][net-http-persistent].
 
+---
+
+:warning: **This README is for the `main` branch that uses Faraday 2.0, which is not yet released.**
+
+For 1.0-compatible documentation, refer to [v1.2.0 of the README](https://github.com/lostisland/faraday-net_http_persistent/blob/v1.2.0/README.md).
+
+---
+
 ## Installation
 
-Add these lines to your application's Gemfile:
+Add this to your application's Gemfile:
 
 ```ruby
-gem 'faraday-net_http_persistent'
-gem 'net-http-persistent', '>= 3.1'
+gem 'faraday-net_http_persistent',
+    git: 'https://github.com/lostisland/faraday-net_http_persistent',
+    branch: 'main'
 ```
 
 And then execute:
 
     $ bundle
 
-Or install them yourself as:
-
-    $ gem install net_http_persistent -v '>= 3.1'
-    $ gem install faraday-net_http_persistent
-
 ## Usage
 
-Configure your Faraday connection to use this adapter instead of the default one:
+Configure your Faraday connection to use the `net_http_persistent` adapter:
 
 ```ruby
 connection = Faraday.new(url, conn_options) do |conn|

--- a/faraday-net_http_persistent.gemspec
+++ b/faraday-net_http_persistent.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob("lib/**/*") + %w[README.md LICENSE.md]
   spec.require_paths = ["lib"]
 
-  # TODO: make this a normal dependency when releasing v2.0
-  spec.add_development_dependency "net-http-persistent", ">= 3.1"
+  spec.add_dependency "faraday", ">= 2.0.0.alpha.pre.2"
+  spec.add_dependency "faraday-net_http"
+  spec.add_dependency "net-http-persistent", ">= 3.1"
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "faraday", "~> 1.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov", "~> 0.19.0"

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
+require "faraday/net_http"
+require "net/http/persistent"
+
 module Faraday
   class Adapter
     # Net::HTTP::Persistent adapter.
     class NetHttpPersistent < NetHttp
-      dependency "net/http/persistent"
-
       private
 
       def net_http_connection(env)


### PR DESCRIPTION
In Faraday 2.0, adapters will be completely opt-in. As a consequence, this adapter can now have a hard dependency on `net_http_persistent`. If a user has opted into adding this adapter to their Gemfile, we know they will be using it.

Thus this PR can make the following changes:

1. Remove the `dependency "net/http/persistent"` declaration. This existed to support loading dependencies on demand, based on what adapter is being used. Since adapters are now explicitly opt-in, this is no longer needed.
2. Add `faraday-net_http` as an explicit dependency. The `faraday-net_http_persistent` adapter subclasses the net_http one. Previously the net_http adapter was part of Faraday core. As of 2.0 it is packaged as a separate gem, so we need to declare it as a dependency.
3. Change the installation instructions. All a user needs to do now is install `faraday-net_http_persistent`. All other dependencies will be included automatically.