### PR TITLE
Faraday 2.0 compatibility update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,15 +25,13 @@ jobs:
           bundler-cache: true
 
       - name: Standard
-        run: |
-          gem install standardrb
-          bundle exec standardrb
+        run: bundle exec standardrb
   build:
     needs: [linting]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7']
+        ruby: ['2.6', '2.7', '3.0']
 
     steps:
       - uses: actions/checkout@v1
@@ -45,5 +43,4 @@ jobs:
           bundler-cache: true
 
       - name: Test
-        run: |
-          bundle exec rake
+        run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
-
-# TODO: remove this once v4 is released
-options = (RUBY_VERSION.start_with?("3") ? {github: "grosser/net-http-persistent", branch: "grosser/spec"} : {})
-gem "net-http-persistent", ">= 3.1", **options
-
 gemspec
+
+gem "bundler", "~> 2.0"
+gem "rake", "~> 13.0"
+gem "rspec", "~> 3.0"
+gem "simplecov", "~> 0.19.0"
+gem "standardrb", "~> 1.0"
+
+gem "multipart-parser", "~> 0.1.1"
+gem "webmock", "~> 3.4"

--- a/faraday-net_http_persistent.gemspec
+++ b/faraday-net_http_persistent.gemspec
@@ -17,21 +17,11 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/lostisland/faraday-net_http_persistent"
-  spec.metadata["changelog_uri"] = "https://github.com/lostisland/faraday-net_http_persistent"
+  spec.metadata["changelog_uri"] = "https://github.com/lostisland/faraday-net_http_persistent/releases/tag/v#{spec.version}"
 
   spec.files = Dir.glob("lib/**/*") + %w[README.md LICENSE.md]
   spec.require_paths = ["lib"]
 
-  # TODO: make this a normal dependency when releasing v2.0
-  spec.add_development_dependency "net-http-persistent", ">= 3.1"
-
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "faraday", "~> 1.0"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "simplecov", "~> 0.19.0"
-  spec.add_development_dependency "standardrb", "~> 1.0"
-
-  spec.add_development_dependency "multipart-parser", "~> 0.1.1"
-  spec.add_development_dependency "webmock", "~> 3.4"
+  spec.add_dependency "faraday-net_http", "~> 2.0.0.alpha-1"
+  spec.add_dependency "net-http-persistent", "~> 4.0"
 end

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -4,8 +4,6 @@ module Faraday
   class Adapter
     # Net::HTTP::Persistent adapter.
     class NetHttpPersistent < NetHttp
-      dependency "net/http/persistent"
-
       private
 
       def net_http_connection(env)

--- a/lib/faraday/net_http_persistent.rb
+++ b/lib/faraday/net_http_persistent.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "faraday/net_http"
+require "net/http/persistent"
 require_relative "adapter/net_http_persistent"
 require_relative "net_http_persistent/version"
 


### PR DESCRIPTION
## Summary

* Update dependencies to be compatible with Faraday 2.0
* Fix net-http-persistent requirement to v4.0+
* Drop Ruby 2.5 support, add Ruby 3.0
* Move development dependencies to Gemfile