### PR TITLE
chore: Move dev deps to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,11 @@
 
 source "https://rubygems.org"
 gemspec
+
+gem "rake", "~> 13.0"
+gem "rspec", "~> 3.0"
+gem "simplecov", "~> 0.19.0"
+gem "standardrb", "~> 1.0"
+
+gem "multipart-parser", "~> 0.1.1"
+gem "webmock", "~> 3.4"

--- a/faraday-net_http_persistent.gemspec
+++ b/faraday-net_http_persistent.gemspec
@@ -25,13 +25,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", ">= 2.0.0.alpha.pre.2"
   spec.add_dependency "faraday-net_http"
   spec.add_dependency "net-http-persistent", ">= 3.1"
-
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "simplecov", "~> 0.19.0"
-  spec.add_development_dependency "standardrb", "~> 1.0"
-
-  spec.add_development_dependency "multipart-parser", "~> 0.1.1"
-  spec.add_development_dependency "webmock", "~> 3.4"
 end


### PR DESCRIPTION
We are using Bundler for our development process, so we can get those development and test dependencies out of the way for normal usage.