### PR TITLE
CI: Drop Ruby 2.5, add Ruby 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7']
+        ruby: ['2.6', '2.7', '3.0']
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
This PR updates the CI matrix.