### PR TITLE
fix: Depend on net-http-persistent 4.x in gemspec

### DIFF
--- a/faraday-net_http_persistent.gemspec
+++ b/faraday-net_http_persistent.gemspec
@@ -13,16 +13,16 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/lostisland/faraday-net_http_persistent"
   spec.license = "MIT"
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/lostisland/faraday-net_http_persistent"
-  spec.metadata["changelog_uri"] = "https://github.com/lostisland/faraday-net_http_persistent"
+  spec.metadata["changelog_uri"] = "https://github.com/lostisland/faraday-net_http_persistent/releases/tag/v#{spec.version}"
 
   spec.files = Dir.glob("lib/**/*") + %w[README.md LICENSE.md]
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", ">= 2.0.0.alpha.pre.2"
   spec.add_dependency "faraday-net_http"
-  spec.add_dependency "net-http-persistent", ">= 3.1"
+  spec.add_dependency "net-http-persistent", "~> 4.0"
 end


### PR DESCRIPTION
This bumps the minimum Ruby version supported to 2.5, due to that gem's dependencies.

Also: Add a specific Changelog URI.