### PR TITLE
Remove dependency from `faraday-net_http` adapter.

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'faraday'
 require 'faraday/net_http_persistent'
 
 # You can add fixtures and/or initialization code here to make experimenting

--- a/faraday-net_http_persistent.gemspec
+++ b/faraday-net_http_persistent.gemspec
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "lib/faraday/net_http_persistent/version"
+lib = File.expand_path("lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "faraday/net_http_persistent/version"
 
 Gem::Specification.new do |spec|
   spec.name = "faraday-net_http_persistent"
@@ -22,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob("lib/**/*") + %w[README.md LICENSE.md]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday-net_http", "< 3"
+  spec.add_dependency "faraday", "~> 2.5"
   spec.add_dependency "net-http-persistent", "~> 4.0"
 end

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -1,28 +1,136 @@
 # frozen_string_literal: true
 
-require "faraday/net_http"
 require "net/http/persistent"
 
 module Faraday
   class Adapter
     # Net::HTTP::Persistent adapter.
-    class NetHttpPersistent < NetHttp
+    class NetHttpPersistent < Faraday::Adapter
+      exceptions = [
+        IOError,
+        Errno::EADDRNOTAVAIL,
+        Errno::EALREADY,
+        Errno::ECONNABORTED,
+        Errno::ECONNREFUSED,
+        Errno::ECONNRESET,
+        Errno::EHOSTUNREACH,
+        Errno::EINVAL,
+        Errno::ENETUNREACH,
+        Errno::EPIPE,
+        Net::HTTPBadResponse,
+        Net::HTTPHeaderSyntaxError,
+        Net::ProtocolError,
+        SocketError,
+        Zlib::GzipFile::Error
+      ]
+
+      exceptions << ::OpenSSL::SSL::SSLError if defined?(::OpenSSL::SSL::SSLError)
+      # TODO (breaking): Enable this to make it consistent with net_http adapter.
+      #   See https://github.com/lostisland/faraday/issues/718#issuecomment-344549382
+      # exceptions << ::Net::OpenTimeout if defined?(::Net::OpenTimeout)
+
+      NET_HTTP_EXCEPTIONS = exceptions.freeze
+
+      def initialize(app = nil, opts = {}, &block)
+        @ssl_cert_store = nil
+        super(app, opts, &block)
+      end
+
+      def call(env)
+        super
+        connection(env) do |http|
+          perform_request(http, env)
+        rescue Net::HTTP::Persistent::Error => e
+          raise Faraday::TimeoutError, e if e.message.include?("Timeout")
+
+          raise Faraday::ConnectionFailed, e if e.message.include?("connection refused")
+
+          raise
+        rescue *NET_HTTP_EXCEPTIONS => e
+          raise Faraday::SSLError, e if defined?(OpenSSL) && e.is_a?(OpenSSL::SSL::SSLError)
+
+          raise Faraday::ConnectionFailed, e
+        end
+        @app.call env
+      rescue Timeout::Error, Errno::ETIMEDOUT => e
+        raise Faraday::TimeoutError, e
+      end
+
       private
 
-      def net_http_connection(env)
-        @cached_connection ||=
-          if Net::HTTP::Persistent.instance_method(:initialize)
-              .parameters.first == %i[key name]
-            options = {name: "Faraday"}
-            options[:pool_size] = @connection_options[:pool_size] if @connection_options.key?(:pool_size)
-            Net::HTTP::Persistent.new(**options)
-          else
-            Net::HTTP::Persistent.new("Faraday")
+      def build_connection(env)
+        net_http_connection(env).tap do |http|
+          http.use_ssl = env[:url].scheme == "https" if http.respond_to?(:use_ssl=)
+          configure_ssl(http, env[:ssl])
+          configure_request(http, env[:request])
+        end
+      end
+
+      def create_request(env)
+        request = Net::HTTPGenericRequest.new \
+          env[:method].to_s.upcase, # request method
+          !!env[:body], # is there request body
+          env[:method] != :head, # is there response body
+          env[:url].request_uri, # request uri path
+          env[:request_headers] # request headers
+
+        if env[:body].respond_to?(:read)
+          request.body_stream = env[:body]
+        else
+          request.body = env[:body]
+        end
+        request
+      end
+
+      def save_http_response(env, http_response)
+        save_response(
+          env, http_response.code.to_i, nil, nil, http_response.message, finished: false
+        ) do |response_headers|
+          http_response.each_header do |key, value|
+            response_headers[key] = value
           end
+        end
+      end
+
+      def configure_request(http, req)
+        if (sec = request_timeout(:read, req))
+          http.read_timeout = sec
+        end
+
+        if (sec = http.respond_to?(:write_timeout=) &&
+          request_timeout(:write, req))
+          http.write_timeout = sec
+        end
+
+        if (sec = request_timeout(:open, req))
+          http.open_timeout = sec
+        end
+
+        # Only set if Net::Http supports it, since Ruby 2.5.
+        http.max_retries = 0 if http.respond_to?(:max_retries=)
+
+        @config_block&.call(http)
+      end
+
+      def ssl_cert_store(ssl)
+        return ssl[:cert_store] if ssl[:cert_store]
+
+        # Use the default cert store by default, i.e. system ca certs
+        @ssl_cert_store ||= OpenSSL::X509::Store.new.tap(&:set_default_paths)
+      end
+
+      def net_http_connection(env)
+        @cached_connection ||= Net::HTTP::Persistent.new(**init_options)
 
         proxy_uri = proxy_uri(env)
         @cached_connection.proxy = proxy_uri if @cached_connection.proxy_uri != proxy_uri
         @cached_connection
+      end
+
+      def init_options
+        options = {name: "Faraday"}
+        options[:pool_size] = @connection_options[:pool_size] if @connection_options.key?(:pool_size)
+        options
       end
 
       def proxy_uri(env)
@@ -33,48 +141,36 @@ module Faraday
           else
             ::URI.parse(proxy[:uri].to_s)
           end
-          proxy_uri.user = proxy_uri.password = nil
-          # awful patch for net-http-persistent 2.8
-          # not unescaping user/password
-          if proxy[:user]
-            (class << proxy_uri; self; end).class_eval do
-              define_method(:user) { proxy[:user] }
-              define_method(:password) { proxy[:password] }
-            end
-          end
+          proxy_uri.user = proxy[:user] if proxy[:user]
+          proxy_uri.password = proxy[:password] if proxy[:password]
         end
         proxy_uri
       end
 
       def perform_request(http, env)
-        if env[:request].stream_response?
-          size = 0
-          yielded = false
+        if env.stream_response?
+          http_response = env.stream_response do |&on_data|
+            request_with_wrapped_block(http, env, &on_data)
+          end
+          http_response.body = nil
+        else
+          http_response = request_with_wrapped_block(http, env)
+        end
+        env.response_body = encoded_body(http_response)
+        env.response.finish(env)
+        http_response
+      end
 
-          http_response = http.request(env[:url], create_request(env)) do |response|
+      def request_with_wrapped_block(http, env)
+        http.request(env[:url], create_request(env)) do |response|
+          save_http_response(env, response)
+
+          if block_given?
             response.read_body do |chunk|
-              if chunk.bytesize.positive? || size.positive?
-                yielded = true
-                size += chunk.bytesize
-                env[:request].on_data.call(chunk, size)
-              end
+              yield(chunk)
             end
           end
-
-          env[:request].on_data.call(+"", 0) unless yielded
-          http_response.body = nil
-          http_response
-        else
-          http.request(env[:url], create_request(env))
         end
-      rescue Errno::ETIMEDOUT, Net::OpenTimeout => e
-        raise Faraday::TimeoutError, e
-      rescue Net::HTTP::Persistent::Error => e
-        raise Faraday::TimeoutError, e if e.message.include? "Timeout"
-
-        raise Faraday::ConnectionFailed, e if e.message.include? "connection refused"
-
-        raise
       end
 
       SSL_CONFIGURATIONS = {
@@ -99,6 +195,27 @@ module Faraday
 
       def http_set(http, attr, value)
         http.send("#{attr}=", value) if http.send(attr) != value
+      end
+
+      def ssl_verify_mode(ssl)
+        ssl[:verify_mode] ||
+          if ssl.fetch(:verify, true)
+            OpenSSL::SSL::VERIFY_PEER
+          else
+            OpenSSL::SSL::VERIFY_NONE
+          end
+      end
+
+      def encoded_body(http_response)
+        body = http_response.body || +""
+        /\bcharset=\s*(.+?)\s*(;|$)/.match(http_response["Content-Type"]) do |match|
+          content_charset = ::Encoding.find(match.captures.first)
+          body = body.dup if body.frozen?
+          body.force_encoding(content_charset)
+        rescue ArgumentError
+          nil
+        end
+        body
       end
     end
   end

--- a/lib/faraday/net_http_persistent.rb
+++ b/lib/faraday/net_http_persistent.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "adapter/net_http_persistent"
-require_relative "net_http_persistent/version"
+require "faraday"
+require "faraday/adapter/net_http_persistent"
+require "faraday/net_http_persistent/version"
 
 module Faraday
   module NetHttpPersistent

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require "simplecov"
+SimpleCov.start
+
 require "faraday"
 require "faraday/net_http_persistent"
-# This is the magic bit. It requires a tests suite from the Faraday gem that you can run against your adapter
 require "faraday_specs_setup"
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Description

* Remove dependency from `faraday-net_http` adapter (Fixes https://github.com/lostisland/faraday-net_http_persistent/issues/14#issuecomment-1209787805)
* Explicitly depend on Faraday 2.5+ (Fixes #13)
* Remove unnecessary `Net::HTTP::Persistent#new` if based on arguments (we now depend on net_http_persistent ~> 4.0)
* Remove unnecessary proxy patch (fixed in https://github.com/drbrain/net-http-persistent/pull/59)
* Use the new streaming API

cc @mattbrictson 