### PR TITLE
CI: Add Ruby 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Standard
         run: |
-          gem install standardrb
-          bundle exec standardrb
+          gem install standardrb -v 1.37.0
+          standardrb
   build:
     needs: [linting]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby 2.7
         uses: ruby/setup-ruby@v1
@@ -33,10 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -45,5 +45,4 @@ jobs:
           bundler-cache: true
 
       - name: Test
-        run: |
-          bundle exec rake
+        run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Ruby 2.7
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: 2.7
           bundler-cache: true
       - run: bundle exec standardrb
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,17 +17,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Ruby 2.7
+      - name: Set up Ruby 3.0
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: '3.0'
           bundler-cache: true
-
-      - name: Standard
-        run: |
-          gem install standardrb -v 1.37.0
-          standardrb
+      - run: bundle exec standardrb
   build:
     needs: [linting]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Ruby 3.0
+      - name: Set up Ruby 2.7
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '2.7'
           bundler-cache: true
       - run: bundle exec standardrb
   build:

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -31,9 +31,9 @@ module Faraday
 
       NET_HTTP_EXCEPTIONS = exceptions.freeze
 
-      def initialize(app = nil, opts = {}, &block)
+      def initialize(app = nil, opts = {}, &)
         @ssl_cert_store = nil
-        super(app, opts, &block)
+        super
       end
 
       def call(env)
@@ -194,7 +194,7 @@ module Faraday
       end
 
       def http_set(http, attr, value)
-        http.send("#{attr}=", value) if http.send(attr) != value
+        http.send(:"#{attr}=", value) if http.send(attr) != value
       end
 
       def ssl_verify_mode(ssl)

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -31,9 +31,9 @@ module Faraday
 
       NET_HTTP_EXCEPTIONS = exceptions.freeze
 
-      def initialize(app = nil, opts = {}, &)
+      def initialize(app = nil, opts = {}, &block)
         @ssl_cert_store = nil
-        super
+        super(app, opts, &block)
       end
 
       def call(env)
@@ -194,7 +194,7 @@ module Faraday
       end
 
       def http_set(http, attr, value)
-        http.send(:"#{attr}=", value) if http.send(attr) != value
+        http.send("#{attr}=", value) if http.send(attr) != value
       end
 
       def ssl_verify_mode(ssl)


### PR DESCRIPTION
This PR adds Ruby 3.3 to the build matrix and updates to the actions/checkout@4.


---


```
ERROR:  Error installing standardrb:
	The last version of standard (>= 0) to support your Ruby & RubyGems was 1.37.0. Try installing it with `gem install standard -v 1.37.0` and then running the current command again
	standard requires Ruby version >= 3.0.0. The current ruby version is 2.7.8.225.
```