### PR TITLE
Fix linting on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,7 @@ jobs:
           bundler-cache: true
 
       - name: Standard
-        run: |
-          gem install standardrb
+        run:
           bundle exec standardrb
   build:
     needs: [linting]

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,1 @@
+ruby_version: 2.6

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ gem "multipart-parser", "~> 0.1.1"
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "simplecov", "~> 0.19.0"
-gem "standardrb", "~> 1.0"
+gem "standard", "~> 1.30.0" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")
 gem "webmock", "~> 3.4"


### PR DESCRIPTION
Use a fixed version of standardrb instead of installing the most recent version every time CI is run.

Also configure StandardRb to be compatible with Ruby 2.6.