### PR TITLE
Add a #close implementation, calling #shutdown on any cached_connection

### DIFF
--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -56,6 +56,10 @@ module Faraday
         raise Faraday::TimeoutError, e
       end
 
+      def close
+        @cached_connection&.shutdown
+      end
+
       private
 
       def build_connection(env)


### PR DESCRIPTION
This PR adds the Faraday adapter #close implementation which calls the Net Http Persistent's `shutdown` method.

See docs for authoring middleware: 

- https://lostisland.github.io/faraday/#/adapters/custom/parallel-requests
- https://lostisland.github.io/faraday/#/adapters/custom/index?id=implementing-close