### PR TITLE
Support verify_hostname

### DIFF
--- a/faraday-net_http_persistent.gemspec
+++ b/faraday-net_http_persistent.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", "~> 2.5"
-  spec.add_dependency "net-http-persistent", "~> 4.0"
+  spec.add_dependency "net-http-persistent", "~> 4.0.4"
 end

--- a/faraday-net_http_persistent.gemspec
+++ b/faraday-net_http_persistent.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", "~> 2.5"
-  spec.add_dependency "net-http-persistent", "~> 4.0.4"
+  spec.add_dependency "net-http-persistent", ">= 4.0.4", "< 5"
 end

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -183,7 +183,8 @@ module Faraday
         ca_file: :ca_file,
         ssl_version: :version,
         min_version: :min_version,
-        max_version: :max_version
+        max_version: :max_version,
+        verify_hostname: :verify_hostname
       }.freeze
 
       def configure_ssl(http, ssl)
@@ -193,7 +194,7 @@ module Faraday
         http_set(http, :cert_store, ssl_cert_store(ssl))
 
         SSL_CONFIGURATIONS
-          .select { |_, key| ssl[key] }
+          .select { |_, key| ssl[key] != nil }
           .each { |target, key| http_set(http, target, ssl[key]) }
       end
 

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -194,7 +194,7 @@ module Faraday
         http_set(http, :cert_store, ssl_cert_store(ssl))
 
         SSL_CONFIGURATIONS
-          .select { |_, key| ssl[key] != nil }
+          .select { |_, key| !ssl[key].nil? }
           .each { |target, key| http_set(http, target, ssl[key]) }
       end
 

--- a/spec/faraday/adapter/net_http_persistent_spec.rb
+++ b/spec/faraday/adapter/net_http_persistent_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe Faraday::Adapter::NetHttpPersistent do
     expect(http.pool.size).to eq(5) if http.respond_to?(:pool)
   end
 
+  it "allows to set verify_hostname in SSL settings to false" do
+    url = URI("https://example.com")
+
+    adapter = described_class.new(nil)
+
+    http = adapter.send(:connection, url: url, request: {})
+    adapter.send(:configure_ssl, http, verify_hostname: false)
+
+    # `verify_hostname` is only present in net_http_persistent >= 4.0.4
+    expect(http.verify_hostname).to eq(false) if http.respond_to?(:verify_hostname)
+  end
+
   context "min_version" do
     it "allows to set min_version in SSL settings" do
       url = URI("https://example.com")
@@ -50,7 +62,7 @@ RSpec.describe Faraday::Adapter::NetHttpPersistent do
       http = adapter.send(:connection, url: url, request: {})
       adapter.send(:configure_ssl, http, min_version: :TLS1_2)
 
-      # `min_version` is only present in net_http_persistent >= 3.1 (UNRELEASED)
+      # `min_version` is only present in net_http_persistent >= 3.1
       expect(http.min_version).to eq(:TLS1_2) if http.respond_to?(:min_version)
     end
   end

--- a/spec/faraday/adapter/net_http_persistent_spec.rb
+++ b/spec/faraday/adapter/net_http_persistent_spec.rb
@@ -37,8 +37,7 @@ RSpec.describe Faraday::Adapter::NetHttpPersistent do
 
     http = adapter.send(:connection, url: url, request: {})
 
-    # `pool` is only present in net_http_persistent >= 3.0
-    expect(http.pool.size).to eq(5) if http.respond_to?(:pool)
+    expect(http.pool.size).to eq(5)
   end
 
   it "allows to set verify_hostname in SSL settings to false" do
@@ -49,8 +48,7 @@ RSpec.describe Faraday::Adapter::NetHttpPersistent do
     http = adapter.send(:connection, url: url, request: {})
     adapter.send(:configure_ssl, http, verify_hostname: false)
 
-    # `verify_hostname` is only present in net_http_persistent >= 4.0.4
-    expect(http.verify_hostname).to eq(false) if http.respond_to?(:verify_hostname)
+    expect(http.verify_hostname).to eq(false)
   end
 
   context "min_version" do
@@ -62,8 +60,7 @@ RSpec.describe Faraday::Adapter::NetHttpPersistent do
       http = adapter.send(:connection, url: url, request: {})
       adapter.send(:configure_ssl, http, min_version: :TLS1_2)
 
-      # `min_version` is only present in net_http_persistent >= 3.1
-      expect(http.min_version).to eq(:TLS1_2) if http.respond_to?(:min_version)
+      expect(http.min_version).to eq(:TLS1_2)
     end
   end
 end


### PR DESCRIPTION
The SSL option `verify_hostname` is now supported in [net-http-persistent 4.0.4](https://github.com/drbrain/net-http-persistent/commit/409b0c73f8c85c879371c62f5af86e33dbae756e): 

This trivial PR passes through the `verify_hostname` option so this feature can be used.

Would it be possible to get a new version of the adapter released? @olleolleolle @iMacTia 