### PR TITLE
Allow specifying connection name

### DIFF
--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -132,7 +132,8 @@ module Faraday
       end
 
       def init_options
-        options = {name: "Faraday"}
+        options = {}
+        options[:name] = @connection_options.fetch(:name, "Faraday")
         options[:pool_size] = @connection_options[:pool_size] if @connection_options.key?(:pool_size)
         options
       end

--- a/spec/faraday/adapter/net_http_persistent_spec.rb
+++ b/spec/faraday/adapter/net_http_persistent_spec.rb
@@ -40,6 +40,26 @@ RSpec.describe Faraday::Adapter::NetHttpPersistent do
     expect(http.pool.size).to eq(5)
   end
 
+  it "allows to set name on initialize" do
+    url = URI("https://example.com")
+
+    adapter = described_class.new(nil, name: "MyCustomName")
+
+    http = adapter.send(:connection, url: url, request: {})
+
+    expect(http.name).to eq("MyCustomName")
+  end
+
+  it "defaults name to Faraday on initialize" do
+    url = URI("https://example.com")
+
+    adapter = described_class.new(nil)
+
+    http = adapter.send(:connection, url: url, request: {})
+
+    expect(http.name).to eq("Faraday")
+  end
+
   it "allows to set verify_hostname in SSL settings to false" do
     url = URI("https://example.com")
 


### PR DESCRIPTION
Allows you to pass a `name:` option to the adapter which is used when initializing the cached connection. This is useful when you have multiple Faraday clients using HTTP persistent, but need to tell them apart in traces, metrics, and so forth.